### PR TITLE
Fix: missing return statement in logWriter configuration closure

### DIFF
--- a/src/scripts.php
+++ b/src/scripts.php
@@ -3,7 +3,7 @@
 if (class_exists('Leaf\Config')) {
     \Leaf\Config::addScript(function () {
         \Leaf\Config::singleton('logWriter', function ($c) {
-            is_object($c['log.writer']) ?
+            return is_object($c['log.writer']) ?
                 $c['log.writer'] :
                 new \Leaf\LogWriter($c['log.dir'] . $c['log.file'], $c['log.open'] ?? true);
         });


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

There is an issue in the Leaf\Config::singleton function where the return statement is required for the logWriter configuration to work correctly. Without the return, the function does not return the expected log.writer object, leading to issues with logging.

**Proposed Fix**: Ensure the function contains the appropriate return statement to return the object as intended.

## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

